### PR TITLE
fix: change login to prevent user enumeration

### DIFF
--- a/src/resolvers/Mutation/auth.ts
+++ b/src/resolvers/Mutation/auth.ts
@@ -17,12 +17,9 @@ export const auth = {
 
   async login(parent, args, ctx: Context, info) {
     const user = await ctx.db.query.user({ where: { email: args.email } })
-    if (!user) {
-      throw new Error('No such user found')
-    }
-
-    const valid = await bcrypt.compare(args.password, user.password)
-    if (!valid) {
+    const valid = await bcrypt.compare(args.password, user ? user.password : '')
+    
+    if (!valid || !user) {
       throw new AuthError()
     }
 


### PR DESCRIPTION
- This fix prevents a malicious user from testing to see if usernames exist without attempting to create new users, aka user enumeration
- Bcrypt is always run to prevent user enumeration timing attacks
- AuthError is always thrown on failure to prevent split response user enumeration

https://blog.rapid7.com/2017/06/15/about-user-enumeration/